### PR TITLE
Work on mac

### DIFF
--- a/src/interfaces.lisp
+++ b/src/interfaces.lisp
@@ -13,11 +13,11 @@
    (baud-rate :initarg :baud-rate
 	      :reader serial-baud-rate
 	      :documentation "baud-rate")
-   (databits :initarg :databits
-	     :reader serial-databits
-	     :documentation "Number of databits.")
-   (stopbits :initarg :stopbits
-	     :accessor serial-stopbits
+   (data-bits :initarg :data-bits
+              :reader serial-data-bits
+              :documentation "Number of data-bits.")
+   (stop-bits :initarg :stop-bits
+              :accessor serial-stop-bits
 	     :documentation "Number of stop-bits")
    (parity :initarg :parity
 	   :accessor serial-parity
@@ -38,8 +38,8 @@
 
 ;;convert to native form.
 (defgeneric% %baud-rate (class &optional baud-rate))
-(defgeneric% %databits (class &optional databits))
-(defgeneric% %stopbits (class &optional stopbits))
+(defgeneric% %data-bits (class &optional data-bits))
+(defgeneric% %stop-bits (class &optional stop-bits))
 (defgeneric% %parity (class &optional parity))
 
 (defgeneric% %valid-fd-p (class))

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -11,7 +11,7 @@
 
 ;;interfaces borrowed from lisp works
 (defun open-serial
-    (&optional name 
+    (&optional name
      &rest args
      &key
      (baud-rate *default-baud-rate*)
@@ -34,8 +34,8 @@
                (if (numberp name) (%default-name *serial-class* name) name)))
   (%open (apply #'make-instance *serial-class*
                 :baud-rate baud-rate
-                :databits data-bits
-                :stopbits stop-bits
+                :data-bits data-bits
+                :stop-bits stop-bits
                 :parity parity
                 :encoding encoding
                 args)
@@ -58,7 +58,7 @@ The result state is a list giving the state of each line in the same order as th
 
 (defun read-serial-char (serial &optional (timeout-error-p t) (timeout-char nil))
   "Reads a character from a serial port."
-  (declare (ignorable timeout-char timeout-error-p)) ;;for now 
+  (declare (ignorable timeout-char timeout-error-p)) ;;for now
   (unless (%valid-fd-p serial)
     (error "invalid serial port ~S" serial))
   (cffi:with-foreign-object (b :unsigned-char 1)
@@ -69,8 +69,8 @@ The result state is a list giving the state of each line in the same order as th
       (loop :do
          (when (= (%read serial b 1) 1)
            (vector-push-extend (cffi:mem-aref b :unsigned-char) v)
-           (let ((res (ignore-errors (babel:octets-to-string 
-                                      v 
+           (let ((res (ignore-errors (babel:octets-to-string
+                                      v
                                       :errorp t
                                       :encoding (serial-encoding serial)))))
              (when res
@@ -110,7 +110,7 @@ The result state is a list giving the state of each line in the same order as th
   nil)
 
 (defun serial-input-available-p (serial)
-  "Checks whether a character is available on a serial port."   
+  "Checks whether a character is available on a serial port."
   (%input-available-p serial))
 
 (defun set-serial-state (serial &key dtr rts break)
@@ -166,8 +166,6 @@ If timeout is non-nil then the function will return nil after that many seconds 
 
 (defmacro with-serial ((serial name &rest params) &body body)
   `(let ((,serial (open-serial ,name ,@params)))
-     (unwind-protect 
+     (unwind-protect
 	  (progn ,@body)
        (close-serial ,serial))))
-
-

--- a/src/posix.lisp
+++ b/src/posix.lisp
@@ -106,7 +106,7 @@
 		  &key
 		    name)
   (let* ((ratedef (%baud-rate s))
-	 (fd (open name (logior o-rdwr o-noctty o-ndelay))))
+	 (fd (open name (logior o-rdwr o-noctty))))
     (when (= -1 fd)
       (error "~A open error!!" name))
     (setf (slot-value s 'fd) fd)

--- a/src/win32.lisp
+++ b/src/win32.lisp
@@ -303,19 +303,19 @@
     ((256000) +CBR_256000+)
     (t (error "not supported baud rate ~A [bps]" baud-rate))))
 
-(defmethod %databits ((s win32-serial) &optional databits)
-  (let ((val (or databits (serial-databits s))))
+(defmethod %data-bits ((s win32-serial) &optional data-bits)
+  (let ((val (or data-bits (serial-data-bits s))))
     (if (<= 4 val 8)
 	val
-	(error "unsupported databits ~A" val))))
+	(error "unsupported data-bits ~A" val))))
 
-(defmethod %stopbits ((s win32-serial) &optional stopbits)
-  (let ((stopbits (or stopbits (serial-stopbits s))))
+(defmethod %stop-bits ((s win32-serial) &optional stop-bits)
+  (let ((stop-bits (or stop-bits (serial-stop-bits s))))
     (cond
-      ((= stopbits 1) +ONESTOPBIT+)
-      ((= stopbits 1.5) +ONE5STOPBITS+)
-      ((= stopbits 2) +TWOSTOPBITS+)
-      (t (error "unsupported stopbits")))))
+      ((= stop-bits 1) +ONESTOPBIT+)
+      ((= stop-bits 1.5) +ONE5STOPBITS+)
+      ((= stop-bits 2) +TWOSTOPBITS+)
+      (t (error "unsupported stop-bits")))))
 
 (defmethod %parity ((s win32-serial) &optional parity)
   (ecase (or parity (serial-parity s))
@@ -359,11 +359,11 @@
 	(setf DCBlength (cffi:foreign-type-size '(:struct dcb))))
       (win32-onerror (win32-get-comm-state fd ptr)
 	(error "GetCommState failed"))
-      (cffi:with-foreign-slots ((baudrate bytesize parity stopbits dcbflags)
+      (cffi:with-foreign-slots ((baudrate bytesize parity stop-bits dcbflags)
 				ptr (:struct dcb))
 	(setf baudrate (%baud-rate s))
-	(setf bytesize (%databits s))
-	(setf stopbits (%stopbits s))
+	(setf bytesize (%data-bits s))
+	(setf stop-bits (%stop-bits s))
 	(setf parity (%parity s))
 	(setf dcbflags (cffi:foreign-bitfield-value 'dcb-flags '(fbinary))))
       (win32-onerror (win32-set-comm-state fd ptr)
@@ -373,7 +373,7 @@
 (defmethod %write ((s win32-serial) buffer seq-size)
   (with-slots (fd) s
     (cffi:with-foreign-object (writtenbytes 'word)
-      (win32-confirm 
+      (win32-confirm
        (win32-write-file fd buffer seq-size writtenbytes (cffi:null-pointer))
        (cffi:mem-ref writtenbytes 'word)
        (error "could not write to device")))))
@@ -381,7 +381,7 @@
 (defmethod %read ((s win32-serial) buf count)
   (with-slots (fd) s
     (cffi:with-foreign-object (readbytes 'word)
-      (win32-confirm 
+      (win32-confirm
        (win32-read-file fd buf count readbytes (cffi:null-pointer))
        (cffi:mem-ref readbytes 'word)
        (error "could not read from device")))))


### PR DESCRIPTION
Hi.
When I use this on my mac. there was some errors. So I fixed them.

### Commit 1: databits => data-bits and stopbits => stop-bits
```
(with-serial (serial "/dev/tty.usbserial-xxx" :data-bits 8 :stop-bits 1) ... )
```
This was not working on my mac. 
- Error :data-bits is invalid argument.

And It started to work with this commit.

### Commit 2: Fixed WOULDBLOCK occurred on (read) on mac.
```
(with-serial (serial "/dev/tty.usbserial-xxx" :baud-rate 9600 :data-bits 8 :stop-bits 1 :baud-rate 9600 :parity :even)
  (let ((stream (make-serial-stream serial)))
    (write-sequence (coerce '(165 2 8 0 11 0 2 0 0 0 0 0 1) 'u8*) stream)
    (let ((res (make-sequence 'u8* #x7F)))
      (read-sequence res stream)
      (format t "~a~%" res))))
```
This was also not working on my mac.
- Error: 35: WOULDBLOCK called. "fd is temporary unavailable". 

And It started to work with this commit.

Best regards.