### PR TITLE
Add :timeout keyword for read/write timeout.

### DIFF
--- a/cserial-port.asd
+++ b/cserial-port.asd
@@ -23,6 +23,7 @@
   #-windows :defsystem-depends-on #-windows (:cffi-grovel)
   :depends-on (:trivial-features
                :trivial-gray-streams
+               :trivial-timeout
                :cffi
                #-windows :cffi-grovel
                #-windows :osicat)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -7,6 +7,7 @@
   (:shadowing-import-from :osicat-posix :open :close :write :read)
   #-windows
   (:import-from :osicat-posix :o-rdwr :o-noctty :o-ndelay :getpgrp :fcntl :f-setfl)
+  (:import-from :trivial-timeout :with-timeout)
   (:import-from :cffi
                 :defcfun
                 :with-foreign-object


### PR DESCRIPTION
If `:timeout` is non-NIL, read/write functions raise a `TRIVIAL-TIMEOUT:TIMEOUT-ERROR` when the `:timeout` second is exceeded.