### PR TITLE
Implement input-available-p and stream-listen for POSIX serial ports.

### DIFF
--- a/src/ffi-types-unix.lisp
+++ b/src/ffi-types-unix.lisp
@@ -122,6 +122,7 @@
 (constant (TIOCMSET "TIOCMSET"))
 (constant (TIOCMBIC "TIOCMBIC"))
 (constant (TIOCMBIS "TIOCMBIS"))
+(constant (FIONREAD "FIONREAD"))
 
 (bitfield modem-state
   ((:dsr "TIOCM_DSR"))

--- a/src/gray.lisp
+++ b/src/gray.lisp
@@ -29,3 +29,6 @@
 
 (defmethod stream-finish-output ((stream serial-stream))
   (close-serial (stream-serial stream)))
+
+(defmethod stream-listen ((stream serial-stream))
+  (serial-input-available-p (stream-serial stream)))

--- a/src/posix.lisp
+++ b/src/posix.lisp
@@ -228,3 +228,10 @@ deci-seconds.")))
             (setf (mem-ref bits :int) (foreign-bitfield-value 'modem-state bits-to-set))
             (unless (zerop (ioctl fd TIOCMBIS bits))
               (error "Unable to set bits"))))))))
+
+(defmethod %input-available-p ((s posix-serial))
+  (with-slots (fd) s
+    (with-foreign-object (nbytes :int)
+      (unless (zerop (ioctl fd FIONREAD nbytes))
+	(error "Unable to get number of bytes available"))
+      (> (mem-ref nbytes :int) 0))))


### PR DESCRIPTION
Implements `input-available-p` for posix serial ports. Tested with SBCL on linux.
Additionally, `stream-listen` is implemented for gray streams.